### PR TITLE
fix(connection): fail only if redis connection does not recover

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,17 +19,25 @@ function isRedisReady(client) {
       resolve();
     } else {
       function handleReady() {
+        client.removeListener('end', handleEnd);
         client.removeListener('error', handleError);
         resolve();
       }
 
+      let lastError;
       function handleError(err) {
+        lastError = err;
+      }
+
+      function handleEnd() {
         client.removeListener('ready', handleReady);
-        reject(err);
+        client.removeListener('error', handleError);
+        reject(lastError);
       }
 
       client.once('ready', handleReady);
-      client.once('error', handleError);
+      client.on('error', handleError);
+      client.once('end', handleEnd);
     }
   });
 }

--- a/test/test_connection.js
+++ b/test/test_connection.js
@@ -123,11 +123,12 @@ describe('connection', () => {
       });
   });
 
-  it('should fail if redis connection fails', done => {
+  it('should fail if redis connection fails and does not reconnect', done => {
     queue = utils.buildQueue('connection fail', {
       redis: {
         host: 'localhost',
-        port: 1234
+        port: 1234,
+        retryStrategy: () => false
       }
     });
 

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -137,7 +137,7 @@ describe('Queue', () => {
 
     it('should create a queue with a redis connection string', () => {
       const queue = new Queue('connstring', 'redis://123.4.5.67:1234/2', {
-        redis: { connectTimeout: 1000 }
+        redis: { connectTimeout: 1000, retryStrategy: () => false }
       });
 
       expect(queue.client.options.host).to.be.eql('123.4.5.67');
@@ -154,7 +154,7 @@ describe('Queue', () => {
 
     it('should create a queue with only a hostname', () => {
       const queue = new Queue('connstring', 'redis://127.2.3.4', {
-        redis: { connectTimeout: 1000 }
+        redis: { connectTimeout: 1000, retryStrategy: () => false }
       });
 
       expect(queue.client.options.host).to.be.eql('127.2.3.4');


### PR DESCRIPTION
On client initialization, Bull waits for the Redis client connection to be 'ready' before trying to send commands to it.
In order to do so, it keeps a promise that only resolves after the Redis client emits a 'ready' event.
It also listens for 'error' events, if an error comes, initialization fails.

However, having an error reported from Redis client, should not fail initialization, because Redis client can retry the connection. Initialization should not fail on the first error it sees, but instead wait for the client to give up on reconnecting. That's why here I'm changing from listening for 'error's and instead listen for the 'end' event, which signals that the client won't try to reconnect anymore or that it failed to establish a connection to the server.

I didn't remove the error listener entirely, it is still useful to keep track of seen error, so when the 'end' occurs we have some information on why the connection failed, by exposing the last seen error.